### PR TITLE
fetches the latest JAR / WAR release

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -3,17 +3,9 @@ mkdir -p src/main/resources
 
 cd src/main/resources
 
-wget https://github.com/validator/validator/releases/download/20141006/vnu-20141013.jar.zip
-unzip *zip
-mv vnu/*jar .
-rm -rf vnu
-rm -rf *zip
+wget https://sideshowbarker.net/releases/jar/vnu.jar
 
-wget https://github.com/validator/validator/releases/download/20141006/vnu-20141013.war.zip
-unzip *zip
-mv vnu/*war .
-rm -rf vnu
-rm -rf *zip
+wget https://sideshowbarker.net/releases/war/vnu.war
 
 cd ../../..
 


### PR DESCRIPTION
The latest release of vnu is now stored on https://sideshowbarker.net/releases/
This ensures that the script always fetches the latest release, so there's no need
to update the script with the location of the jar and war files.